### PR TITLE
Add ONNX export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <div align="center">
 
-
-
 **Collection of tasks for fast baseline solving in self-driving problems with deep learning. The offical language support is Pytorch** 
-
 
 ---
 
@@ -17,7 +14,6 @@
   <a href="#license">License</a>
 </p>
 
-
 </div>
 
 ---
@@ -25,7 +21,6 @@
 __Note:__ This pkg is currently in development. Please [open an issue](https://github.com/HCMUS-ROBOTICS/ssdf-nncore/issues/new/choose) if you find anything that isn't working as expected.
 
 ---
-
 
 ## Installation
 
@@ -40,17 +35,19 @@ non-support yet
 
 To install **nncore** and develop locally
 
-```
+```bash
 git clone https://github.com/HCMUS-ROBOTICS/ssdf-nncore nncore 
 cd nncore/nn
 pip install -r requirements.txt
 ```
+
 See [Installation]() for more options.
 </details>
 
 ---
 
 ## What is NNcore
+
 NNcore is a deep learning framework focusing on solving autonomous-driving problems.
 
 - Task-based training and export for multiple framework
@@ -92,10 +89,9 @@ if __name__ == "__main__":
 
 ### Training
 
-
 <details>
   <summary>training configs</summary>
-cfg/opt.yaml 
+cfg/opt.yaml
 
 ```yaml
 
@@ -126,9 +122,9 @@ opts:
 
 ```
 
-pipeline.yaml 
+pipeline.yaml
 
-```yaml 
+```yaml
 
 learner:
   name: # learner name
@@ -188,10 +184,9 @@ data:
 
 ```
 
-
 </details>
 
-train.py 
+train.py
 
 ```python
 
@@ -237,19 +232,30 @@ this repo
 |    train.py
 |    test.py
 ```
+
 more information [here](examples/segmentation)
+
+## Export to ONNX
+
+Use the script provided in `examples`, then run below command
+
+```bash
+PYTHONPATH=.. python3 torch2onnx.py <checkpoint> --in_shape 1 3 224 224 --inputs input --outputs output
+```
 
 ## A general task
 
 Nothing here yet
+
 ## Customizable
 
 Nothing here yet
+
 ## Visualization
 
-Predictions from vision tasks can be visualized through an [Tensorboard](), allowing you to better understand and analyze how your model is performing.
+Predictions from vision tasks can be visualized through an [Tensorboard](https://www.tensorflow.org/tensorboard), allowing you to better understand and analyze how your model is performing.
 
-## References 
+## References
 
 Nothing here yet
 

--- a/examples/torch2onnx.py
+++ b/examples/torch2onnx.py
@@ -1,0 +1,36 @@
+import argparse
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.onnx
+import yaml
+from nncore.utils import getter
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Export model to onnx")
+    parser.add_argument("checkpoint", type=Path, help="Path to checkpoint")
+    parser.add_argument("--opset", type=int, default=13)
+    parser.add_argument('--in_shape', type=int, nargs="+", required=True)
+    parser.add_argument('--inputs', type=str, nargs='+', required=True)
+    parser.add_argument('--outputs', type=str, nargs='+', required=True)
+    args = parser.parse_args()
+
+    # Config from checkpoint
+    ckpt_dir: Path = args.checkpoint.parent
+    with (ckpt_dir / "config.yaml").open() as config_file:
+        config = yaml.safe_load(config_file)
+
+    # Load model
+    model_config = config["pipeline"]["model"]
+    model: nn.Module = getter.get_instance(model_config)
+    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    model.load_state_dict(ckpt["model_state_dict"])
+
+    model_name: str = model_config["name"]
+    in_shape_str = "x".join(map(str, args.in_shape))
+    onnx_name = f"{model_config['name']}-{in_shape_str}.onnx"
+    torch.onnx.export(model, torch.randn(args.in_shape), onnx_name, opset_version=args.opset,
+                      input_names=args.inputs, output_names=args.outputs)
+
+    print(f"Exported to {onnx_name}")

--- a/nncore/learner/supervisedlearner.py
+++ b/nncore/learner/supervisedlearner.py
@@ -1,31 +1,26 @@
-import torch
-from ..datasets import *
-from ..utils.typing import *
-from ..utils import *
-from ..test import evaluate
-from ..schedulers import *
+from pathlib import Path
 
-import numpy as np
+import torch
+from torch import device
+from torch.cuda.amp import GradScaler, autocast
+from torch.nn import Module
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
-from torch.nn import Module
-from torch import device
-import cv2
 
-from pathlib import Path
-from torch.cuda.amp import GradScaler, autocast
-
-from .baselearner import BaseLearner
+from ..datasets import *
 from ..metrics import Metric
-
-from torchvision.utils import save_image
+from ..schedulers import *
+from ..test import evaluate
+from ..utils import *
+from ..utils.typing import *
+from .baselearner import BaseLearner
 
 
 class SupervisedLearner(BaseLearner):
     r"""SupervisedLearner class 
 
     Support training and evaluate strategy for supervise learning 
-    
+
     Args:
         cfg (Any): [description]
         save_dir (str): save folder directory path
@@ -116,7 +111,6 @@ class SupervisedLearner(BaseLearner):
     def save_checkpoint(
         self, epoch: int, val_loss: float, val_metric: Dict[str, float]
     ) -> None:
-
         r"""Save checkpoint method
 
         Saving 


### PR DESCRIPTION
The script parses pipeplie configuration from checkpoint's directory, then export ONNX file named **model_name**-**input_shape**.onnx i.e. MobileUnet-1x3x224x224.onnx
Instead of hardcorded sys.path in the source code, I think we should encourage users to use the PYTHONPATH environment variable `PYTHONPATH=.. python3 torch2onnx.py checkpoint --in_shape 1 3 224 224 --inputs input --outputs output`

Edit: typo